### PR TITLE
Levelmanager upgrade

### DIFF
--- a/core/src/com/sweatyreptile/losergame/LevelManager.java
+++ b/core/src/com/sweatyreptile/losergame/LevelManager.java
@@ -70,7 +70,7 @@ public class LevelManager {
 	}
 	
 	public void nextlevel() {
-		// Wow look it's a stub!
+		// Wow, you've reached a stub!
 		
 		// To be called to switch to the level
 		// that comes after the current level

--- a/core/src/com/sweatyreptile/losergame/LevelTimer.java
+++ b/core/src/com/sweatyreptile/losergame/LevelTimer.java
@@ -11,14 +11,14 @@ public class LevelTimer {
 	private static final float WIDTH = 0.015f;
 	private float viewportWidth;
 	private float viewportHeight;
-	private LevelScreen level;
+	private LevelManager levelManager;
 	
 	private float totalSeconds;
 	private boolean on;
 	private float timePassed;
 		
-	public LevelTimer(LevelScreen level, float viewportWidth, float viewportHeight, float totalSeconds){
-		this.level = level;
+	public LevelTimer(LevelManager levelManager, float viewportWidth, float viewportHeight, float totalSeconds){
+		this.levelManager = levelManager;
 		this.viewportWidth = viewportWidth;
 		this.viewportHeight = viewportHeight;
 		this.totalSeconds = totalSeconds;
@@ -45,7 +45,7 @@ public class LevelTimer {
 				Gdx.app.postRunnable(new Runnable() {
 					@Override
 					public void run() {
-						level.finish();
+						levelManager.restart();
 					}
 				});
 			}

--- a/core/src/com/sweatyreptile/losergame/screens/LevelScreen.java
+++ b/core/src/com/sweatyreptile/losergame/screens/LevelScreen.java
@@ -232,7 +232,7 @@ public abstract class LevelScreen implements FinishableScreen{
 
 		if (timeLimit >= 0){
 			limitedTime = true;
-			levelTimer = new LevelTimer(this, viewportWidth, viewportHeight, timeLimit); //timeLimit in seconds
+			levelTimer = new LevelTimer(levelManager, viewportWidth, viewportHeight, timeLimit); //timeLimit in seconds
 		}
 		if (limitedTime) levelTimer.start();
 	}
@@ -273,7 +273,11 @@ public abstract class LevelScreen implements FinishableScreen{
 	protected abstract void setupWorld();
 
 	public void finish() {
-		levelManager.level(alias);
+		// Do things that should be done after the 
+		// player accomplishes whatever needs to
+		// be accomplished in order to complete
+		// the level
+		levelManager.nextlevel();
 	}
 
 	@Override


### PR DESCRIPTION
Two new methods, `restart()` and `nextlevel()`.

Restart is to be used when a level has been failed, or something else has happened to cause the current level to restart.

Nextlevel is to be used when a level has been completed, so that the next level may be switched to.
